### PR TITLE
Prefer source code URLs over homepage URLs

### DIFF
--- a/lib/gem_dandy/gem_change.rb
+++ b/lib/gem_dandy/gem_change.rb
@@ -26,7 +26,7 @@ module GemDandy
     end
 
     def github_url
-      [homepage_url, source_code_url].find { |url| url && url[/github.com/] }
+      [source_code_url, homepage_url].find { |url| url && url[/github.com/] }
     end
 
     def changelog_url


### PR DESCRIPTION
httparty's homepage url has `github` in the url but that isn't actually
it's source code. This fixes that problem.