### PR TITLE
Attempt to load the changelog from Rubygems before searching GitHub

### DIFF
--- a/lib/gem_dandy/gem_change.rb
+++ b/lib/gem_dandy/gem_change.rb
@@ -30,7 +30,10 @@ module GemDandy
     end
 
     def changelog_url
-      @changelog_url ||= Github::Changelog.for(github_repo, current_tag)
+      @changelog_url ||= begin
+        url_for('changelog_uri') ||
+          Github::Changelog.for(github_repo, current_tag)
+      end
     end
 
     def compare_url

--- a/spec/lib/gem_dandy/gem_change_spec.rb
+++ b/spec/lib/gem_dandy/gem_change_spec.rb
@@ -126,7 +126,15 @@ RSpec.describe GemDandy::GemChange do
   end
 
   describe '#changelog_url' do
-    it 'delegates to Github::Changelog.for' do
+    it 'first attempts to load the changelog from rubygems' do
+      allow(subject).to receive(:rubygems_info)
+        .and_return('changelog_uri' => changelog_url)
+
+      expect(subject.changelog_url).to eq(changelog_url)
+    end
+
+    it 'otherwise delegates to Github::Changelog.for' do
+      allow(subject).to receive(:rubygems_info).and_return({})
       allow(subject).to receive(:github_url).and_return(github_url)
       allow(GemDandy::Github::Changelog).to receive(:for)
         .and_return(changelog_url)


### PR DESCRIPTION
This is especially useful for gems which are stored in larger projects with other libraries. The maintainer can specify the exact location of their changelog so we don't have to go hunting for it.

Example: https://rubygems.org/api/v1/gems/selenium-webdriver.json

```ruby
{
  name: "selenium-webdriver",
  changelog_uri: "https://github.com/SeleniumHQ/selenium/blob/master/rb/CHANGES"
}
```